### PR TITLE
Gets userAgent information for the server

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -16,6 +16,7 @@
     "quasar-framework": "^0.14.4",
     "serve-favicon": "^2.4.5",
     "vue": "~2.3.4",
+    "vue-no-ssr": "^0.2.0",
     "vue-router": "^2.7.0"
   },
   "devDependencies": {

--- a/template/server.js
+++ b/template/server.js
@@ -21,10 +21,10 @@ function createRenderer (bundle, options) {
   // https://github.com/vuejs/vue/blob/dev/packages/vue-server-renderer/README.md#why-use-bundlerenderer
   return createBundleRenderer(bundle, Object.assign(options, {
     // for component caching
-    cache: isProd ? require('lru-cache')({
-      max: 1000,
-      maxAge: 1000 * 60 * 15
-    }) : undefined,
+    // cache: isProd ? require('lru-cache')({
+    //   max: 1000,
+    //   maxAge: 1000 * 60 * 15
+    // }) : undefined,
     // recommended for performance
     runInNewContext: false
   }))

--- a/template/src/server-entry.js
+++ b/template/src/server-entry.js
@@ -1,20 +1,27 @@
+import { 
+  Platform,
+  getPlatform
+} from 'quasar'
+
 module.exports = function(context) {
 
   return new Promise((resolve, reject) => {
 
-    global.userAgent = context.userAgent
-    var { app, router } = require('./main.js').default;
+    // This allows us to render platform dependant components and avoid hydration errors
+    Platform.is = getPlatform(context.userAgent)
+
+    var { app, router, appContext } = require('./main.js').default
 
     // `router.push()` will load the url provided by our context and getMatchedComponents will retrieve all the associated parent and child components related to that url
-    router.push(context.url);
+    router.push(context.url)
 
     router.onReady(() => {
-      let matchedComponents = router.getMatchedComponents();
+      let matchedComponents = router.getMatchedComponents()
 
       // no matched routes
       if (!matchedComponents.length) {
 
-        return Promise.reject(new Error(`There are no vue components for this url: ${context.url}`));
+        return Promise.reject(new Error(`There are no vue components for this url: ${context.url}`))
       }
 
       // We wait for the "ssr" hook to finish it's promises before rendering. You can run an isomorphic ajax library such as axios or isomorphic-fetch in it. It should be a function You that returns a promise and when it resolves it will render the html. This allows you to fetch all your ajax data before the html is sent and save the results to a store
@@ -24,7 +31,7 @@ module.exports = function(context) {
           return component.asyncData({
             // store,
             route: router.currentRoute
-          });
+          })
         }
         else {
           return undefined
@@ -32,11 +39,11 @@ module.exports = function(context) {
       }))
         .then(() => {
           // If you have a vuex or vue stash store, save the results to context.state
-          // context.state = store.state;
-          return app;
+          // context.state = store.state
+          return app
         })
         .then(resolve)
-        .catch(reject);
+        .catch(reject)
     })
   })
-};
+}


### PR DESCRIPTION
In anticipation of ssr in quasar-framework adds logic to get userAgent information from the server without setting a global variable.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch and _not_ the `master` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] It's been tested with all Quasar themes
- [ ] It's been tested on a Cordova (iOS, Android) app
- [ ] It's been tested on a Electron app
- [x] Any necessary documentation has been added or updated [in the docs](https://github.com/quasarframework/quasar-framework.org/tree/master/source) (for faster update click on "Suggest an edit on GitHub" at bottom of page) or explained in the PR's description.

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
